### PR TITLE
Adding a Django developement environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-#Vagrant
+# Vagrant
 .vagrant/
+
+# nohup
+nohup.*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,10 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end
+  config.vm.network(
+    "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+  )
+  config.vm.provision "shell", path: "setup.sh", privileged: false
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
- Setup [Pipenv] [1] to install and manage Django and other Python dependencies
- Bootstrapped an empty [Django] [2] application
- Setup Vagrant to automatically brnig our application up as well as make it accessible from a web browser

After running 'vagrant up' the application can be accessed at:

> http://127.0.0.1:8000/

**Note:** Most changes had been auto-generated, only 'Vagrantfile' and 'setup.sh' had been edited manually.

[1] https://github.com/pypa/pipenv
[2] https://www.djangoproject.com/